### PR TITLE
Tf port

### DIFF
--- a/Disco_tf.py
+++ b/Disco_tf.py
@@ -54,4 +54,6 @@ def distance_corr(var_1, var_2, normedweight, power=1):
         dCorr = (tf.reduce_mean(ABavg*normedweight))**2/(tf.reduce_mean(AAavg*normedweight)*tf.reduce_mean(BBavg*normedweight))
     else:
         dCorr = tf.reduce_mean(ABavg*normedweight)/tf.math.sqrt(tf.reduce_mean(AAavg*normedweight)*tf.reduce_mean(BBavg*normedweight))**power
+    
+    return dCorr
 


### PR DESCRIPTION
I added a tensorflow version of Disco.py. It was a nice little exercise and I think I got everything right. Looking forward to any further suggestions. Otherwise it could be merged into master branch.

Short question abot the dCorr variable: In the pytorch version, if power is neither 2 nor 1 ('else' case), the exponential is used for the demoninator only, as opposed for the cases of 1 and 2, where 'power' is used on the whole fraction. Is this supposed to be like this?